### PR TITLE
add resource group location to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ Default: `null`
 
 The following outputs are exported:
 
+### <a name="output_location"></a> [location](#output\_location)
+
+Description: The location of the resource group
+
 ### <a name="output_name"></a> [name](#output\_name)
 
 Description: The name of the resource group

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,3 +12,8 @@ output "resource_id" {
   description = "The resource Id of the resource group"
   value       = azurerm_resource_group.this.id
 }
+
+output "location" {
+  description = "The location of the resource group"
+  value       = azurerm_resource_group.this.location
+}


### PR DESCRIPTION
## Description

Adding Resource Group location (region) to module outputs. Helps build implicit dependancies with other modules.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
