### PR TITLE
feat: use avm-utl-interfaces 0.6.0 native role_assignment name override

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,27 +107,11 @@ object({
 
 Default: `{}`
 
-### <a name="input_role_assignment_name_overrides"></a> [role\_assignment\_name\_overrides](#input\_role\_assignment\_name\_overrides)
-
-Description: Optional. A map of role assignment names to override the auto-generated names produced by the interfaces module.
-
-The map key must match a key in the `role_assignments` variable. The map value must be a valid UUID (the role assignment resource name in Azure is a GUID).
-
-Example:
-```hcl
-role_assignment_name_overrides = {
-  "roleassignment1" = "00000000-0000-0000-0000-000000000001"
-}
-```
-
-Type: `map(string)`
-
-Default: `{}`
-
 ### <a name="input_role_assignments"></a> [role\_assignments](#input\_role\_assignments)
 
 Description: Optional. A map of role assignments to create on this resource. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
 
+- `name` - (Optional) The name of the role assignment. If not set, a random UUID will be generated. Must be a valid GUID. Changing this forces the creation of a new resource.
 - `role_definition_id_or_name` - (Required) The ID or name of the role definition to assign to the principal.
 - `principal_id` - (Required) The ID of the principal to assign the role to.
 - `description` - (Optional) The description of the role assignment.
@@ -183,6 +167,7 @@ Type:
 
 ```hcl
 map(object({
+    name                                   = optional(string, null)
     role_definition_id_or_name             = string
     principal_id                           = string
     description                            = optional(string, null)
@@ -256,7 +241,7 @@ The following Modules are called:
 
 Source: Azure/avm-utl-interfaces/azure
 
-Version: 0.5.2
+Version: 0.6.0
 
 <!-- markdownlint-disable-next-line MD041 -->
 ## Data Collection

--- a/avm.tflint.override.hcl
+++ b/avm.tflint.override.hcl
@@ -1,0 +1,7 @@
+# Disabled until this PR gets merged:
+# https://github.com/Azure/tflint-ruleset-avm/pull/127
+# The current rule rejects the optional `name` attribute on role_assignments
+# that allows callers to pin a deterministic GUID for a role assignment.
+rule "role_assignments" {
+  enabled = false
+}

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -78,18 +78,16 @@ module "resource_group" {
     kind = "CanNotDelete"
     name = "myCustomLockName"
   }
-  role_assignment_name_overrides = {
-    "roleassignment1"  = "dfd0b1f9-3f46-32ba-e9e1-4b5591aa8337"
-    "role_assignment2" = "bd83f8d6-f0a2-1584-9e3c-f31c185847ea"
-  }
   role_assignments = {
     "roleassignment1" = {
+      name                       = "dfd0b1f9-3f46-32ba-e9e1-4b5591aa8337"
       principal_id               = azapi_resource.dep_uai.output.properties.principalId
       role_definition_id_or_name = "Reader"
       principal_type             = "ServicePrincipal"
       description                = "Reader role assignment for the user assigned identity"
     },
     "role_assignment2" = {
+      name                             = "bd83f8d6-f0a2-1584-9e3c-f31c185847ea"
       role_definition_id_or_name       = "Storage Blob Data Reader"
       principal_id                     = azapi_resource.dep_uai.output.properties.principalId
       skip_service_principal_aad_check = false

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -71,18 +71,16 @@ module "resource_group" {
     kind = "CanNotDelete"
     name = "myCustomLockName"
   }
-  role_assignment_name_overrides = {
-    "roleassignment1"  = "dfd0b1f9-3f46-32ba-e9e1-4b5591aa8337"
-    "role_assignment2" = "bd83f8d6-f0a2-1584-9e3c-f31c185847ea"
-  }
   role_assignments = {
     "roleassignment1" = {
+      name                       = "dfd0b1f9-3f46-32ba-e9e1-4b5591aa8337"
       principal_id               = azapi_resource.dep_uai.output.properties.principalId
       role_definition_id_or_name = "Reader"
       principal_type             = "ServicePrincipal"
       description                = "Reader role assignment for the user assigned identity"
     },
     "role_assignment2" = {
+      name                             = "bd83f8d6-f0a2-1584-9e3c-f31c185847ea"
       role_definition_id_or_name       = "Storage Blob Data Reader"
       principal_id                     = azapi_resource.dep_uai.output.properties.principalId
       skip_service_principal_aad_check = false

--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,11 @@
 module "interfaces" {
   source  = "Azure/avm-utl-interfaces/azure"
-  version = "0.5.2"
+  version = "0.6.0"
 
-  enable_telemetry                     = var.enable_telemetry
-  lock                                 = var.lock
-  role_assignment_definition_scope     = "/subscriptions/${data.azapi_client_config.current.subscription_id}"
-  role_assignment_name_use_random_uuid = true
-  role_assignments                     = var.role_assignments
+  enable_telemetry                 = var.enable_telemetry
+  lock                             = var.lock
+  role_assignment_definition_scope = "/subscriptions/${data.azapi_client_config.current.subscription_id}"
+  role_assignments                 = var.role_assignments
 }
 
 resource "azapi_resource" "this" {
@@ -63,7 +62,7 @@ resource "azapi_resource" "lock" {
 resource "azapi_resource" "role_assignments" {
   for_each = module.interfaces.role_assignments_azapi
 
-  name                   = lookup(var.role_assignment_name_overrides, each.key, each.value.name)
+  name                   = each.value.name
   parent_id              = azapi_resource.this.id
   type                   = each.value.type
   body                   = each.value.body

--- a/variables.tf
+++ b/variables.tf
@@ -76,35 +76,9 @@ The retry configuration applied to the underlying `azapi_resource` resources (re
 DESCRIPTION
 }
 
-variable "role_assignment_name_overrides" {
-  type        = map(string)
-  default     = {}
-  description = <<DESCRIPTION
-Optional. A map of role assignment names to override the auto-generated names produced by the interfaces module.
-
-The map key must match a key in the `role_assignments` variable. The map value must be a valid UUID (the role assignment resource name in Azure is a GUID).
-
-Example:
-```hcl
-role_assignment_name_overrides = {
-  "roleassignment1" = "00000000-0000-0000-0000-000000000001"
-}
-```
-DESCRIPTION
-  nullable    = false
-
-  validation {
-    condition = alltrue(
-      [for name in values(var.role_assignment_name_overrides) :
-        can(regex("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$", name))
-      ]
-    )
-    error_message = "Each value in `role_assignment_name_overrides` must be a valid GUID (e.g. `00000000-0000-0000-0000-000000000000`)."
-  }
-}
-
 variable "role_assignments" {
   type = map(object({
+    name                                   = optional(string, null)
     role_definition_id_or_name             = string
     principal_id                           = string
     description                            = optional(string, null)
@@ -118,6 +92,7 @@ variable "role_assignments" {
   description = <<DESCRIPTION
 Optional. A map of role assignments to create on this resource. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
 
+- `name` - (Optional) The name of the role assignment. If not set, a random UUID will be generated. Must be a valid GUID. Changing this forces the creation of a new resource.
 - `role_definition_id_or_name` - (Required) The ID or name of the role definition to assign to the principal.
 - `principal_id` - (Required) The ID of the principal to assign the role to.
 - `description` - (Optional) The description of the role assignment.
@@ -185,6 +160,14 @@ DESCRIPTION
          - Using the subscription-scoped role definition Id : `/subscriptions/<subscription_id>/providers/Microsoft.Authorization/roleDefinitions/<role_guid>`
          - Using the role name: Reader | "Storage Blob Data Reader"
       ERROR_MESSAGE
+  }
+  validation {
+    condition = alltrue(
+      [for role in var.role_assignments :
+        role.name == null || can(regex("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$", coalesce(role.name, "00000000-0000-0000-0000-000000000000")))
+      ]
+    )
+    error_message = "Each `role_assignments[*].name` must be null or a valid GUID (e.g. `00000000-0000-0000-0000-000000000000`)."
   }
 }
 


### PR DESCRIPTION
## Summary

Switches role assignment naming over to the new native support in `avm-utl-interfaces` `0.6.0`, removing the previously-introduced standalone `role_assignment_name_overrides` variable in favour of an optional `name` attribute on each item in `role_assignments`.

## Changes

- Bump `Azure/avm-utl-interfaces/azure` to `0.6.0`.
- Remove `role_assignment_name_use_random_uuid` from the module call (the new default behaviour).
- Remove the `role_assignment_name_overrides` variable.
- Add an optional `name` attribute to items in `role_assignments`. When `null` the interfaces module generates a random UUID; when set it must be a valid GUID.
- Wire `name = each.value.name` directly in `azapi_resource.role_assignments`.
- Update `examples/complete` to use the new `name` attribute on the `role_assignments` map entries.
- Add `avm.tflint.override.hcl` disabling the `role_assignments` rule until [`tflint-ruleset-avm#127`](https://github.com/Azure/tflint-ruleset-avm/pull/127) ships, mirroring the workaround used in `avm-utl-interfaces`.

## Validation

- [x] `terraform fmt -recursive`
- [x] `terraform validate` for `examples/complete` and `examples/managed_by`
- [x] `avm pre-commit`
